### PR TITLE
Allow port to be nil in (str (map->URL))

### DIFF
--- a/src/cemerick/url.clj
+++ b/src/cemerick/url.clj
@@ -35,7 +35,8 @@
 
 (defn- port-str
   [protocol port]
-  (when (and (not= -1 port)
+  (when (and (not= nil port)
+             (not= -1 port)
              (not (and (== port 80) (= protocol "http")))
              (not (and (== port 443) (= protocol "https"))))
     (str ":" port)))

--- a/test/cemerick/test_url.clj
+++ b/test/cemerick/test_url.clj
@@ -31,7 +31,8 @@
   (is (= "http://localhost:8080" (url-str "http://localhost:8080")))
   (is (= "https://localhost" (url-str "https://localhost")))
   (is (= "https://localhost" (url-str "https://localhost:443")))
-  (is (= "https://localhost:8443" (url-str "https://localhost:8443"))))
+  (is (= "https://localhost:8443" (url-str "https://localhost:8443")))
+  (is (= "http://localhost" (str (map->URL {:host "localhost" :protocol "http"})))))
 
 (deftest user-info-edgecases
   (are [user-info url-string] (= user-info ((juxt :username :password) (url url-string)))


### PR DESCRIPTION
Treat :port nil the same as :port -1. Makes (map->URL) more pleasant to use. 
