### PR TITLE
handle edge cases in query-params

### DIFF
--- a/src/cemerick/url.clj
+++ b/src/cemerick/url.clj
@@ -24,12 +24,19 @@
     flatten
     (apply str)))
 
+(defn split-param [param]
+  (->
+   (.split param "=")
+   (concat (repeat ""))
+   (->>
+    (take 2))))
+
 (defn- query->map
   [qstr]
   (when qstr
     (-?>> (.split qstr "&")
       seq
-      (mapcat #(.split % "="))
+      (mapcat split-param)
       (map url-decode)
       (apply hash-map))))
 

--- a/test/cemerick/test_url.clj
+++ b/test/cemerick/test_url.clj
@@ -9,7 +9,8 @@
   (are [x y] (= x (#'cemerick.url/map->query y))
        "a=1&b=2&c=3" {:a 1 :b 2 :c 3}
        "a=1&b=2&c=3" {:a "1"  :b "2" :c "3"}
-       "a=1&b=2" {"a" "1" "b" "2"}))
+       "a=1&b=2" {"a" "1" "b" "2"}
+       "a=" {"a" ""}))
 
 (deftest url-roundtripping
   (let [aurl (url "https://username:password@some.host.com/database?query=string")]
@@ -35,6 +36,13 @@
   (when-let [map->URL (resolve 'map->URL)]
     ; map record factory fn not available under Clojure 1.2.0
     (is (= "http://localhost" (str (map->URL {:host "localhost" :protocol "http"}))))))
+
+(deftest query-params
+  (are [query map] (is (= map (#'cemerick.url/query->map query)))
+    "a=b" {"a" "b"}
+    "a=1&b=2&c=3" {"a" "1" "b" "2" "c" "3"}
+    "a=" {"a" ""}
+    "a" {"a" ""}))
 
 (deftest user-info-edgecases
   (are [user-info url-string] (= user-info ((juxt :username :password) (url url-string)))


### PR DESCRIPTION
This handles query params like "https://foo.com/?label" and "?label=" They're not well-defined in the spec, but they do appear to happen in the wild. 
