### PR TITLE
Enhance map->query with an escape hatch for a different encoder

### DIFF
--- a/src/cemerick/url.cljx
+++ b/src/cemerick/url.cljx
@@ -27,16 +27,18 @@
   (some-> string str (js/decodeURIComponent)))
 
 (defn map->query
-  [m]
-  (some->> (seq m)
-    sort                     ; sorting makes testing a lot easier :-)
-    (map (fn [[k v]]
-           [(url-encode (name k))
-            "="
-            (url-encode (str v))]))
-    (interpose "&")
-    flatten
-    (apply str)))
+  [{:as m :keys [override-encoder-fn]}]
+  (let [encoder-fn (or override-encoder-fn url-encode)
+        m (dissoc m :override-encoder-fn)]
+    (some->> (seq m)
+             sort                     ; sorting makes testing a lot easier :-)
+             (map (fn [[k v]]
+                    [(encoder-fn (name k))
+                     "="
+                     (encoder-fn (str v))]))
+             (interpose "&")
+             flatten
+             (apply str))))
 
 (defn split-param [param]
   (->

--- a/test/cemerick/test_url.cljx
+++ b/test/cemerick/test_url.cljx
@@ -13,8 +13,15 @@
        "a=1&b=2&c=3" {:a 1 :b 2 :c 3}
        "a=1&b=2&c=3" {:a "1"  :b "2" :c "3"}
        "a=1&b=2" {"a" "1" "b" "2"}
-       "a=" {"a" ""}
-       "overridden=overridden" {:foo "bar" :override-encoder-fn (constantly "overridden")}))
+       "a=" {"a" ""}))
+
+(defmethod url-encode :append-foobar
+  [string _]
+  (str string "foobar"))
+
+(deftest test-map-to-query-str-extention
+  (is (= "afoobar=custom-encodingfoobar"
+      (map->query {:a "custom-encoding"} :append-foobar))))
 
 (deftest url-roundtripping
   (let [aurl (url "https://username:password@some.host.com/database?query=string")]

--- a/test/cemerick/test_url.cljx
+++ b/test/cemerick/test_url.cljx
@@ -13,7 +13,8 @@
        "a=1&b=2&c=3" {:a 1 :b 2 :c 3}
        "a=1&b=2&c=3" {:a "1"  :b "2" :c "3"}
        "a=1&b=2" {"a" "1" "b" "2"}
-       "a=" {"a" ""}))
+       "a=" {"a" ""}
+       "overridden=overridden" {:foo "bar" :override-encoder-fn (constantly "overridden")}))
 
 (deftest url-roundtripping
   (let [aurl (url "https://username:password@some.host.com/database?query=string")]


### PR DESCRIPTION
Problem: Cannot use any encoding other than utf-8
Solution: Make the fn aware of a special keyword where the value is a fn used for encoding instead of the default one.