### PR TITLE
Allow repeated keys in query params

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.cemerick/url "0.1.2-SNAPSHOT"
+(defproject aaronblenkush/url "0.1.3"
   :description "Makes working with URLs in Clojure a little more pleasant."
   :url "http://github.com/cemerick/url"
   :license {:name "Eclipse Public License"

--- a/src/cemerick/url.cljx
+++ b/src/cemerick/url.cljx
@@ -54,11 +54,12 @@
       seq
       (reduce (fn [params param]
                 (let [[k v] (map url-decode (split-param param))]
-                  (->> (fn [vs]
-                         (if vs
-                           (conj (if (vector? vs) vs [vs]) v)
-                           v))
-                       (update params k))))
+                  (->> ((fn [vs]
+                          (if vs
+                            (conj (if (vector? vs) vs [vs]) v)
+                            v))
+                         (get params k))
+                       (assoc params k))))
               {}))))
 
 (defn- port-str


### PR DESCRIPTION
This will allow repeated params in the query string as requested in issue #13.

`query->map`

    (= (query->map "fq=1&fq=2&a=4&fq=3")
        {"fq" ["1" "2" "3"], "a" "4"})

`map->query`

    (= (map->query {"fq" ["1" "2" "3"], "a" "4"})
        "a=4&fq=1&fq=2&fq=3")

