### PR TITLE
Update pathetic to version 1.5.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [pathetic "0.5.0"]
+                 [pathetic "0.5.1"]
                  [org.clojure/clojurescript "0.0-1835" :optional true]]
 
   :source-paths ["src" "target/generated-src"]


### PR DESCRIPTION
pethetic 1.5.0 has a dependency on clojurescript, that was fixed in
1.5.1.

https://github.com/davidsantiago/pathetic/commit/f3aacf0f7d00c2a9f56c841155ef2bdc79b2c309