### PR TITLE
Allow a mix of keyword and string keys in :query

### DIFF
--- a/src/cemerick/url.cljx
+++ b/src/cemerick/url.cljx
@@ -29,7 +29,7 @@
 (defn map->query
   [m]
   (some->> (seq m)
-    sort                     ; sorting makes testing a lot easier :-)
+    (sort-by (fn [[k v]] (name k)))  ; sorting makes testing a lot easier :-)
     (map (fn [[k v]]
            [(url-encode (name k))
             "="

--- a/test/cemerick/test_url.cljx
+++ b/test/cemerick/test_url.cljx
@@ -47,6 +47,12 @@
     nil nil
     "" nil))
 
+(deftest query-mixed-keys
+  (is (= "https://localhost:80?baz=bam&foo=bar"
+         (-> (url "https://localhost:80?foo=bar")
+                (assoc-in [:query :baz] "bam")
+                str))))
+
 (deftest user-info-edgecases
   (are [user-info url-string] (= user-info ((juxt :username :password) (url url-string)))
     ["a" nil] "http://a@foo"


### PR DESCRIPTION
url/parse returns a query-map of strings to strings and the
README provides examples of associng keyword keys into the
query map. Using these features in combination caused
the sort in map->query to blow up with a ClassCastException.